### PR TITLE
Add option for disabling images during conversion.

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+DISABLE_IMAGES="${DISABLE_IMAGES:-false}"
+
 if [ -t 0 ]; then 
 	>&2 echo This script must be run with a file or pipe as stdin
 fi
@@ -11,8 +13,13 @@ fi
 # Now convert that file to html
 mhonarc -single -rcfile /mhonarc.rc "/vol/$1" > /tmp/input.html
 
-# And finally convert to PDF
-wkhtmltopdf /tmp/input.html /tmp/output.pdf >/dev/null
+# And finally convert to PDF (disable images to reduce probability of ECONNREFUSED errors)
+if [ "$DISABLE_IMAGES" == "true" ]
+then
+  wkhtmltopdf --no-images /tmp/input.html /tmp/output.pdf >/dev/null
+else
+  wkhtmltopdf /tmp/input.html /tmp/output.pdf >/dev/null
+fi
 
 # Now echo the file to stdout
 cat /tmp/output.pdf


### PR DESCRIPTION
I keep getting ECONNREFUSED errors when converting certain emails with images in them despite seeing no TCP `RST`s in `tcpdump -i any`. I also couldn't get `wkhtmltopdf` to print more verbose information. However, adding `--disable-images` to `wkhtmltopdf` seems to fix it. Weird.

This PR allows users to disable images to fix this with an environment variable.